### PR TITLE
docs: add plugin module comments

### DIFF
--- a/lib/plugins/console/clean.ts
+++ b/lib/plugins/console/clean.ts
@@ -2,6 +2,14 @@ import Promise from 'bluebird';
 import { exists, unlink, rmdir } from 'hexo-fs';
 import type Hexo from '../../hexo';
 
+/**
+ * `hexo clean`
+ *
+ * Removes generated files, cache database and public folder to give the site
+ * a fresh state. Executed before certain commands like `hexo generate` to
+ * ensure stale files are cleared.
+ */
+
 function cleanConsole(this: Hexo): Promise<[void, void, any]> {
   return Promise.all([
     deleteDatabase(this),

--- a/lib/plugins/console/config.ts
+++ b/lib/plugins/console/config.ts
@@ -4,6 +4,14 @@ import { extname } from 'path';
 import Promise from 'bluebird';
 import type Hexo from '../../hexo';
 
+/**
+ * `hexo config`
+ *
+ * Reads or writes values in the main `_config.yml`/`_config.json` file. Without
+ * arguments it prints the entire configuration; with a key it prints that
+ * value, and with both key and value it updates the configuration file.
+ */
+
 interface ConfigArgs {
   _: string[]
   [key: string]: any

--- a/lib/plugins/console/deploy.ts
+++ b/lib/plugins/console/deploy.ts
@@ -3,6 +3,14 @@ import { underline, magenta } from 'picocolors';
 import type Hexo from '../../hexo';
 import type Promise from 'bluebird';
 
+/**
+ * `hexo deploy`
+ *
+ * Sends the generated site to a deployment target. If the public folder is
+ * missing, it automatically triggers a generation step before running
+ * registered deployer plugins.
+ */
+
 interface DeployArgs {
   _?: string[]
   g?: boolean

--- a/lib/plugins/console/generate.ts
+++ b/lib/plugins/console/generate.ts
@@ -9,6 +9,13 @@ import { createSha1Hash } from 'hexo-util';
 import type Hexo from '../../hexo';
 import type Router from '../../hexo/router';
 
+/**
+ * `hexo generate`
+ *
+ * Converts source files into static assets. Supports incremental builds,
+ * cleaning of outdated files and optional deployment or file watching modes.
+ */
+
 interface GenerateArgs {
   f?: boolean
   force?: boolean

--- a/lib/plugins/console/index.ts
+++ b/lib/plugins/console/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers Hexo's built-in console commands.
+ *
+ * Each command (e.g. `hexo clean`, `hexo generate`) is defined in its own
+ * module and plugged into the CLI here along with descriptions and options
+ * that describe its usage.
+ */
 import type Hexo from '../../hexo';
 
 export = function(ctx: Hexo) {

--- a/lib/plugins/console/list/category.ts
+++ b/lib/plugins/console/list/category.ts
@@ -6,6 +6,10 @@ import type { CategorySchema } from '../../../types';
 import type Model from 'warehouse/dist/model';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Lists all categories with their post counts in a tabular form.
+ */
+
 function listCategory(this: Hexo): void {
   const categories: Model<CategorySchema> = this.model('Category');
 

--- a/lib/plugins/console/list/common.ts
+++ b/lib/plugins/console/list/common.ts
@@ -1,5 +1,12 @@
 import strip from 'strip-ansi';
 
+/**
+ * Utility helpers shared by list subcommands.
+ *
+ * Currently provides a `stringLength` function that measures the visual length
+ * of console strings, accounting for ANSI colors and double-byte characters.
+ */
+
 export function stringLength(str: string): number {
   str = strip(str);
 

--- a/lib/plugins/console/list/index.ts
+++ b/lib/plugins/console/list/index.ts
@@ -7,6 +7,14 @@ import category from './category';
 import type Hexo from '../../../hexo';
 import type Promise from 'bluebird';
 
+/**
+ * `hexo list <type>`
+ *
+ * Lists information about different Hexo entities such as posts, pages,
+ * routes, tags and categories. Each type has its own handler module that
+ * outputs formatted details to the console.
+ */
+
 interface ListArgs {
   _: string[]
 }

--- a/lib/plugins/console/list/page.ts
+++ b/lib/plugins/console/list/page.ts
@@ -6,6 +6,10 @@ import type { PageSchema } from '../../../types';
 import type Model from 'warehouse/dist/model';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Displays all static pages with their dates, titles and source paths.
+ */
+
 function listPage(this: Hexo): void {
   const Page: Model<PageSchema> = this.model('Page');
 

--- a/lib/plugins/console/list/post.ts
+++ b/lib/plugins/console/list/post.ts
@@ -6,6 +6,11 @@ import type { PostSchema } from '../../../types';
 import type Model from 'warehouse/dist/model';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Lists posts with metadata including publication status, path, categories and
+ * tags.
+ */
+
 function mapName(item: any): string {
   return item.name;
 }

--- a/lib/plugins/console/list/route.ts
+++ b/lib/plugins/console/list/route.ts
@@ -1,6 +1,11 @@
 import archy from 'archy';
 import type Hexo from '../../../hexo';
 
+/**
+ * Prints all generated routes as a tree, showing the structure of the public
+ * URLs that will be generated.
+ */
+
 function listRoute(this: Hexo): void {
   const routes = this.route.list().sort();
   const tree = buildTree(routes);

--- a/lib/plugins/console/list/tag.ts
+++ b/lib/plugins/console/list/tag.ts
@@ -6,6 +6,10 @@ import type { TagSchema } from '../../../types';
 import type Model from 'warehouse/dist/model';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Shows all tags, how many posts use each tag and the URL of their archives.
+ */
+
 function listTag(this: Hexo): void {
   const Tag: Model<TagSchema> = this.model('Tag');
 

--- a/lib/plugins/console/migrate.ts
+++ b/lib/plugins/console/migrate.ts
@@ -1,6 +1,14 @@
 import { underline, magenta } from 'picocolors';
 import type Hexo from '../../hexo';
 
+/**
+ * `hexo migrate`
+ *
+ * Runs migrator plugins to import content from other platforms into the
+ * current Hexo site. Lists available migrators if the requested type is not
+ * installed.
+ */
+
 interface MigrateArgs {
   _: string[]
   [key: string]: any

--- a/lib/plugins/console/new.ts
+++ b/lib/plugins/console/new.ts
@@ -4,6 +4,14 @@ import { basename } from 'path';
 import Hexo from '../../hexo';
 import type Promise from 'bluebird';
 
+/**
+ * `hexo new`
+ *
+ * Creates a new post, page or other content type. Accepts optional layout,
+ * slug and path arguments and passes remaining flags directly to the post
+ * generator.
+ */
+
 const reservedKeys = {
   _: true,
   title: true,

--- a/lib/plugins/console/publish.ts
+++ b/lib/plugins/console/publish.ts
@@ -3,6 +3,14 @@ import { magenta } from 'picocolors';
 import type Hexo from '../../hexo';
 import type Promise from 'bluebird';
 
+/**
+ * `hexo publish`
+ *
+ * Moves a draft post to the posts folder, effectively publishing it. The
+ * command accepts a layout argument and can replace existing posts when the
+ * `--replace` flag is provided.
+ */
+
 interface PublishArgs {
   _: string[]
   r?: boolean

--- a/lib/plugins/console/render.ts
+++ b/lib/plugins/console/render.ts
@@ -6,6 +6,14 @@ import { cyan, magenta } from 'picocolors';
 import type Hexo from '../../hexo';
 import type Promise from 'bluebird';
 
+/**
+ * `hexo render`
+ *
+ * Renders a file with Hexo's renderer plugins and optionally writes the result
+ * to a destination path. Useful for testing renderers outside of the full
+ * generation pipeline.
+ */
+
 interface RenderArgs {
   _: string[]
   o?: string

--- a/lib/plugins/filter/index.ts
+++ b/lib/plugins/filter/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers built-in filters that run at various points in Hexo's lifecycle.
+ *
+ * Filters are tiny plugins that transform data or hook into events such as
+ * rendering and exiting. Each filter is loaded from its own module and
+ * registered under an appropriate name.
+ */
 import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/plugins/filter/new_post_path.ts
+++ b/lib/plugins/filter/new_post_path.ts
@@ -6,6 +6,13 @@ import { ensurePath } from 'hexo-fs';
 import type Hexo from '../../hexo';
 import type { PostSchema } from '../../types';
 
+/**
+ * Determines the file path for new posts or drafts.
+ *
+ * Uses the `new_post_name` template and optional slug/path values to build a
+ * collision-free destination and creates directories when necessary.
+ */
+
 let permalink: Permalink;
 
 const reservedKeys = {

--- a/lib/plugins/filter/post_permalink.ts
+++ b/lib/plugins/filter/post_permalink.ts
@@ -3,6 +3,13 @@ import { basename } from 'path';
 import type Hexo from '../../hexo';
 import type { PostSchema } from '../../types';
 
+/**
+ * Generates the permalink for a post using the configured pattern.
+ *
+ * Falls back to default categories and handles asset folder conventions when
+ * the permalink does not end with a slash or extension.
+ */
+
 let permalink: Permalink;
 
 function postPermalinkFilter(this: Hexo, data: PostSchema): string {

--- a/lib/plugins/generator/asset.ts
+++ b/lib/plugins/generator/asset.ts
@@ -6,11 +6,24 @@ import type Hexo from '../../hexo';
 import type { AssetSchema, BaseGeneratorReturn } from '../../types';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Structured data returned for each processed asset.
+ *
+ * `modified` indicates whether the source file has changed and therefore
+ * needs to be re-rendered. `data` is an optional function that returns the
+ * content of the asset, either a rendered string or a readable stream.
+ */
 interface AssetData {
   modified: boolean;
   data?: () => any;
 }
 
+/**
+ * Shape of the objects returned by the asset generator.
+ *
+ * The `data` property contains runtime metadata about the asset as well as a
+ * function to retrieve the asset content during generation.
+ */
 interface AssetGenerator extends BaseGeneratorReturn {
   data: {
     modified: boolean;
@@ -18,6 +31,16 @@ interface AssetGenerator extends BaseGeneratorReturn {
   }
 }
 
+/**
+ * Load and prepare assets from the specified model.
+ *
+ * The method performs a two-step process:
+ * 1. Filter out assets whose source files no longer exist. Missing files are
+ *    removed from the database to keep the model in sync with the file system.
+ * 2. Map each remaining asset to an object containing its destination path and
+ *    a function for obtaining its data. Renderable assets are rendered to
+ *    strings, while non-renderable ones are read as streams.
+ */
 const process = (name: string, ctx: Hexo) => {
   return Promise.filter(ctx.model(name).toArray(), (asset: Document<AssetSchema>) => exists(asset.source).tap(exist => {
     if (!exist) return asset.remove();
@@ -29,7 +52,7 @@ const process = (name: string, ctx: Hexo) => {
     };
 
     if (asset.renderable && ctx.render.isRenderable(path)) {
-      // Replace extension name if the asset is renderable
+      // Replace extension name if the asset can be rendered to another format
       const filename = path.substring(0, path.length - extname(path).length);
 
       path = `${filename}.${ctx.render.getOutput(path)}`;
@@ -41,6 +64,7 @@ const process = (name: string, ctx: Hexo) => {
         ctx.log.error({err}, 'Asset render failed: %s', magenta(path));
       });
     } else {
+      // Non-renderable assets are served directly from disk as streams
       data.data = () => createReadStream(source);
     }
 
@@ -48,6 +72,12 @@ const process = (name: string, ctx: Hexo) => {
   });
 };
 
+/**
+ * Register the asset generator.
+ *
+ * It processes both "Asset" and "PostAsset" models and flattens the results
+ * into a single array consumed by Hexo's generation pipeline.
+ */
 function assetGenerator(this: Hexo): Promise<AssetGenerator[]> {
   return Promise.all([
     process('Asset', this),

--- a/lib/plugins/generator/index.ts
+++ b/lib/plugins/generator/index.ts
@@ -1,9 +1,19 @@
 import type Hexo from '../../hexo';
 
+/**
+ * Attach built-in generators to the provided Hexo instance.
+ *
+ * Generators transform source models into routable files during the render
+ * phase. Each registration maps a name to the corresponding generator
+ * implementation.
+ */
 export = (ctx: Hexo) => {
   const { generator } = ctx.extend;
 
+  // Generate static asset files such as images or other resources.
   generator.register('asset', require('./asset'));
+  // Generate regular pages (about, contact, etc.).
   generator.register('page', require('./page'));
+  // Generate blog posts.
   generator.register('post', require('./post'));
 };

--- a/lib/plugins/generator/page.ts
+++ b/lib/plugins/generator/page.ts
@@ -1,17 +1,34 @@
 import type { BaseGeneratorReturn, PageSchema, SiteLocals } from '../../types';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * A simplified representation used when a page opts out of layouts and only
+ * needs its raw content to be written to the target path.
+ */
 type SimplePageGenerator = Omit<BaseGeneratorReturn, 'layout'> & { data: string };
+
+/**
+ * Full representation for standard pages that use layouts.
+ */
 interface NormalPageGenerator extends BaseGeneratorReturn {
   layout: string[];
   data: PageSchema;
 }
+
 type PageGenerator = SimplePageGenerator | NormalPageGenerator;
 
+/**
+ * Convert `locals.pages` into a set of generation instructions.
+ *
+ * Each page is mapped to an object containing its destination path and either
+ * raw content or a reference to the page model (for further processing with
+ * layouts).
+ */
 function pageGenerator(locals: SiteLocals): PageGenerator[] {
   return locals.pages.map((page: Document<PageSchema> & PageSchema) => {
     const { path, layout } = page;
 
+    // When a page disables layouts, output the content directly.
     if (!layout || layout === 'false' || layout === 'off') {
       return {
         path,
@@ -19,9 +36,12 @@ function pageGenerator(locals: SiteLocals): PageGenerator[] {
       };
     }
 
+    // Determine the layout search order. The explicit layout has highest
+    // priority followed by the defaults.
     const layouts = ['page', 'post', 'index'];
     if (layout !== 'page') layouts.unshift(layout);
 
+    // Flag the page as processed so that downstream logic can identify it.
     page.__page = true;
 
     return {

--- a/lib/plugins/generator/post.ts
+++ b/lib/plugins/generator/post.ts
@@ -1,13 +1,24 @@
 import type { BaseGeneratorReturn, PostSchema, SiteLocals } from '../../types';
 import type Document from 'warehouse/dist/document';
 
+/**
+ * Representation for posts that bypass layouts and only output raw content.
+ */
 type SimplePostGenerator = Omit<BaseGeneratorReturn, 'layout'> & { data: string };
+
+/**
+ * Representation for regular posts making use of layouts.
+ */
 interface NormalPostGenerator extends BaseGeneratorReturn {
   data: PostSchema | Document<PostSchema>;
   layout: string[];
 }
+
 type PostGenerator = SimplePostGenerator | NormalPostGenerator;
 
+/**
+ * Convert `locals.posts` into a set of generation instructions ordered by date.
+ */
 function postGenerator(locals: SiteLocals): PostGenerator[] {
   const posts = locals.posts.sort('-date').toArray();
   const { length } = posts;
@@ -15,6 +26,7 @@ function postGenerator(locals: SiteLocals): PostGenerator[] {
   return posts.map((post: Document<PostSchema>, i: number) => {
     const { path, layout } = post;
 
+    // If layout is disabled, output the rendered content directly.
     if (!layout || layout === 'false') {
       return {
         path,
@@ -22,12 +34,15 @@ function postGenerator(locals: SiteLocals): PostGenerator[] {
       };
     }
 
+    // Populate links to previous and next posts for navigation.
     if (i) post.prev = posts[i - 1];
     if (i < length - 1) post.next = posts[i + 1];
 
+    // Determine layout search order: user-specified layout first, then defaults.
     const layouts = ['post', 'page', 'index'];
     if (layout !== 'post') layouts.unshift(layout);
 
+    // Flag to mark the object as a post during later processing stages.
     post.__post = true;
 
     return {

--- a/lib/plugins/helper/date.ts
+++ b/lib/plugins/helper/date.ts
@@ -3,6 +3,14 @@ const { isMoment } = moment;
 import moize from 'moize';
 import type { LocalsType } from '../../types';
 
+/**
+ * Date and time helper functions used within templates.
+ *
+ * Provides wrappers around Moment.js for consistent locale and timezone
+ * handling as well as formatting utilities such as `date`, `time` and
+ * `moment`.
+ */
+
 const isDate = (value: moment.MomentInput | moment.Moment): boolean =>
   typeof value === 'object' && value instanceof Date && !isNaN(value.getTime());
 

--- a/lib/plugins/helper/index.ts
+++ b/lib/plugins/helper/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers utility helpers available in Hexo templates.
+ *
+ * Helpers provide reusable template logic such as date formatting, asset URLs
+ * and HTML tag generators. Each helper module exports one or more functions
+ * that are exposed through `ctx.extend.helper`.
+ */
 import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/plugins/highlight/index.ts
+++ b/lib/plugins/highlight/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Registers syntax highlighters available to Hexo.
+ *
+ * Currently supports `highlight.js` and `prismjs` implementations, allowing
+ * themes to choose their preferred library for code blocks.
+ */
 import type Hexo from '../../hexo';
 
 module.exports = (ctx: Hexo) => {

--- a/lib/plugins/injector/index.ts
+++ b/lib/plugins/injector/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Placeholder for future injector plugins.
+ *
+ * The injector extension allows themes and plugins to append snippets into
+ * various sections of the generated pages. Hexo currently ships without any
+ * built-in injectors but sets up the extension point for external modules.
+ */
 import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/plugins/processor/asset.ts
+++ b/lib/plugins/processor/asset.ts
@@ -9,6 +9,14 @@ import type Hexo from '../../hexo';
 import type { Stats } from 'fs';
 import { PageSchema } from '../../types';
 
+/**
+ * Processor for files in the source directory.
+ *
+ * Decides whether a file should be rendered as a page or copied directly as an
+ * asset based on its extension and `skip_render` rules. Also updates existing
+ * records using front-matter metadata.
+ */
+
 export = (ctx: Hexo) => {
   return {
     pattern: new Pattern(path => {

--- a/lib/plugins/processor/index.ts
+++ b/lib/plugins/processor/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers processors that handle source files before generation.
+ *
+ * Processors parse specific file types (assets, data files, posts) and convert
+ * them into internal models or routes. Each processor exports a pattern and
+ * process function which are wired up here.
+ */
 import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/plugins/renderer/index.ts
+++ b/lib/plugins/renderer/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Registers default renderers used to transform source files into other
+ * formats.
+ *
+ * Includes pass-through renderers for static files as well as specific ones
+ * for JSON, YAML and Nunjucks templates.
+ */
 import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/plugins/tag/index.ts
+++ b/lib/plugins/tag/index.ts
@@ -1,6 +1,13 @@
 import moize from 'moize';
 import type Hexo from '../../hexo';
 
+/**
+ * Registers built-in tag plugins for Markdown and templates.
+ *
+ * Tag plugins provide convenient syntax for embedding content such as images,
+ * blockquotes and code blocks. Each tag is implemented in its own module and
+ * may perform asynchronous work when rendering.
+ */
 export default (ctx: Hexo) => {
   const { tag } = ctx.extend;
 


### PR DESCRIPTION
## Summary
- document built-in console commands, filters, helpers and other plugin modules
- clarify processor and renderer registration logic

## Testing
- `npm test` *(fails: AssertionError in asset processor tests)*
- `npm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_68a9b601670c832094ae81b993e98ba0